### PR TITLE
Add finance QA workflow

### DIFF
--- a/agents/qa_system_finance/__init__.py
+++ b/agents/qa_system_finance/__init__.py
@@ -1,0 +1,5 @@
+"""Finance QA system agents using Google ADK."""
+
+from .workflow import supervisor_agent
+
+__all__ = ["supervisor_agent"]

--- a/agents/qa_system_finance/financial_summary.py
+++ b/agents/qa_system_finance/financial_summary.py
@@ -1,0 +1,29 @@
+"""Fetch simple financial summary using Yahoo Finance."""
+
+from __future__ import annotations
+
+import requests
+
+
+SUMMARY_URL = (
+    "https://query1.finance.yahoo.com/v10/finance/quoteSummary/{ticker}"
+)
+
+
+MODULES = ["earnings", "defaultKeyStatistics"]
+
+
+def get_financial_summary(ticker: str) -> dict:
+    """Retrieve earnings summary data from Yahoo Finance."""
+    url = SUMMARY_URL.format(ticker=ticker)
+    try:
+        resp = requests.get(url, params={"modules": ",".join(MODULES)}, timeout=10)
+    except Exception as exc:
+        return {"status": "error", "error_message": str(exc)}
+    if resp.status_code != 200:
+        return {"status": "error", "error_message": f"HTTP {resp.status_code}"}
+    data = resp.json()
+    result = data.get("quoteSummary", {}).get("result")
+    if not result:
+        return {"status": "error", "error_message": "No summary data"}
+    return {"status": "success", "summary": result[0]}

--- a/agents/qa_system_finance/news_retrieval.py
+++ b/agents/qa_system_finance/news_retrieval.py
@@ -1,0 +1,36 @@
+"""Retrieve news headlines using DuckDuckGo."""
+
+from __future__ import annotations
+
+import requests
+from typing import List, Dict
+
+
+DUCKDUCKGO_URL = "https://duckduckgo.com/"
+
+
+def search_news(query: str, max_results: int = 5) -> dict:
+    """Search DuckDuckGo news and return titles and snippets."""
+    params = {
+        "q": query,
+        "format": "json",
+        "no_redirect": 1,
+        "no_html": 1,
+        "skip_disambig": 1,
+        "t": "adk-agent",
+    }
+    try:
+        resp = requests.get(DUCKDUCKGO_URL, params=params, timeout=10)
+    except Exception as exc:
+        return {"status": "error", "error_message": str(exc)}
+    if resp.status_code != 200:
+        return {"status": "error", "error_message": f"HTTP {resp.status_code}"}
+    data = resp.json()
+    results: List[Dict[str, str]] = []
+    for item in data.get("results", [])[:max_results]:
+        results.append({
+            "title": item.get("title"),
+            "snippet": item.get("snippet"),
+            "url": item.get("url"),
+        })
+    return {"status": "success", "articles": results}

--- a/agents/qa_system_finance/sentiment_analysis.py
+++ b/agents/qa_system_finance/sentiment_analysis.py
@@ -1,0 +1,27 @@
+"""Simple sentiment analysis utility."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+POSITIVE_WORDS = {"good", "positive", "growth", "gain", "strong", "improve"}
+NEGATIVE_WORDS = {"bad", "negative", "decline", "loss", "weak", "drop"}
+
+
+def analyze_sentiment(text: str) -> dict:
+    """Very naive sentiment analysis based on word counts."""
+    text_lower = text.lower()
+    score = 0
+    for word in POSITIVE_WORDS:
+        if word in text_lower:
+            score += 1
+    for word in NEGATIVE_WORDS:
+        if word in text_lower:
+            score -= 1
+    if score > 0:
+        sentiment = "positive"
+    elif score < 0:
+        sentiment = "negative"
+    else:
+        sentiment = "neutral"
+    return {"status": "success", "sentiment": sentiment, "score": score}

--- a/agents/qa_system_finance/ticker_validation.py
+++ b/agents/qa_system_finance/ticker_validation.py
@@ -1,0 +1,24 @@
+"""Utilities to validate stock tickers using Yahoo Finance."""
+
+from __future__ import annotations
+
+import requests
+
+
+YAHOO_QUOTE_URL = "https://query1.finance.yahoo.com/v7/finance/quote"
+
+
+def validate_ticker(ticker: str) -> dict:
+    """Validate a ticker symbol via Yahoo Finance."""
+    try:
+        resp = requests.get(YAHOO_QUOTE_URL, params={"symbols": ticker}, timeout=10)
+    except Exception as exc:
+        return {"status": "error", "error_message": str(exc)}
+    if resp.status_code != 200:
+        return {"status": "error", "error_message": f"HTTP {resp.status_code}"}
+
+    data = resp.json()
+    results = data.get("quoteResponse", {}).get("result", [])
+    if not results:
+        return {"status": "error", "error_message": f"Ticker '{ticker}' not found"}
+    return {"status": "success", "data": results[0]}

--- a/agents/qa_system_finance/workflow.py
+++ b/agents/qa_system_finance/workflow.py
@@ -1,0 +1,73 @@
+"""Stock price analysis agent workflow using Google ADK."""
+
+from __future__ import annotations
+
+from google.adk.agents import LlmAgent
+from google.adk.tools import FunctionTool
+
+from .ticker_validation import validate_ticker
+from .news_retrieval import search_news
+from .financial_summary import get_financial_summary
+from .sentiment_analysis import analyze_sentiment
+
+# Tools wrapping the utility functions
+validate_ticker_tool = FunctionTool(func=validate_ticker)
+news_retrieval_tool = FunctionTool(func=search_news)
+financial_summary_tool = FunctionTool(func=get_financial_summary)
+sentiment_analysis_tool = FunctionTool(func=analyze_sentiment)
+
+# Sub agents
+ticker_validation_agent = LlmAgent(
+    name="TickerValidationAgent",
+    model="gemini-2.0-pro",
+    instruction=(
+        "Validate the given stock ticker using the provided tool. "
+        "Return an error if the ticker is invalid."
+    ),
+    tools=[validate_ticker_tool],
+)
+
+news_retrieval_agent = LlmAgent(
+    name="NewsRetrievalAgent",
+    model="gemini-2.0-pro",
+    instruction=(
+        "Search recent news for the ticker and the specified week using the "
+        "search_news tool. Summarize the headlines."
+    ),
+    tools=[news_retrieval_tool],
+)
+
+financial_summary_agent = LlmAgent(
+    name="FinancialSummaryAgent",
+    model="gemini-2.0-pro",
+    instruction=(
+        "Fetch financial results such as earnings using the provided tool."
+    ),
+    tools=[financial_summary_tool],
+)
+
+sentiment_analysis_agent = LlmAgent(
+    name="SentimentAnalysisAgent",
+    model="gemini-2.0-pro",
+    instruction=(
+        "Analyze sentiment of text using the analyze_sentiment tool and "
+        "report whether it is positive, negative, or neutral."
+    ),
+    tools=[sentiment_analysis_tool],
+)
+
+# Supervisor agent orchestrating the workflow
+supervisor_agent = LlmAgent(
+    name="StockSupervisorAgent",
+    model="gemini-2.0-pro",
+    instruction=(
+        "You are a supervisor agent that coordinates sub agents to analyze "
+        "why a stock moved during a given week."
+    ),
+    sub_agents=[
+        ticker_validation_agent,
+        news_retrieval_agent,
+        financial_summary_agent,
+        sentiment_analysis_agent,
+    ],
+)


### PR DESCRIPTION
## Summary
- add new `qa_system_finance` package with LlmAgent workflow
- provide tools for ticker validation, news retrieval, financial summary, and sentiment analysis

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d82d277c4832185058fdaa64af0eb