### PR TITLE
Add finance QA system agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 uv.lock
 .venv/*
 .env
+tests/*
 adk_handson.egg-info/*
 adk-samples/*
 common/__pycache__/*
 agents/__pycache__/*
 agents/multi_tool_agent/__pycache__/*
 agents/common/__pycache__/*
+adk_samples.egg-info/*

--- a/agents/qa_system_finance/__init__.py
+++ b/agents/qa_system_finance/__init__.py
@@ -1,0 +1,6 @@
+from .util import (
+    analyze_sentiment,
+    search_news,
+    summarize_financials,
+    validate_ticker,
+)

--- a/agents/qa_system_finance/agent.py
+++ b/agents/qa_system_finance/agent.py
@@ -21,7 +21,7 @@ if GOOGLE_GENAI_USE_VERTEXAI:
 
 ticker_validation_agent = LlmAgent(
     name="ticker_validator",
-    model="gemini-2.0-pro",
+    model=MODEL_NAME,
     instruction=(
         "Use the validate_ticker tool to check if the ticker provided by the "
         "user exists on Yahoo Finance. If the ticker is invalid, return an "

--- a/agents/qa_system_finance/agent.py
+++ b/agents/qa_system_finance/agent.py
@@ -1,0 +1,80 @@
+import os
+
+from google.adk.agents import LlmAgent
+
+from agents.common.util import load_env
+from agents.common.vertex_setup import setup_vertexai
+from agents.qa_system_finance import (
+    analyze_sentiment,
+    search_news,
+    summarize_financials,
+    validate_ticker,
+)
+
+load_env()
+GOOGLE_GENAI_USE_VERTEXAI = os.getenv("GOOGLE_GENAI_USE_VERTEXAI")
+PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT")
+REGION = os.getenv("GOOGLE_CLOUD_LOCATION")
+
+if GOOGLE_GENAI_USE_VERTEXAI:
+    setup_vertexai(project=PROJECT, region=REGION)
+
+ticker_validation_agent = LlmAgent(
+    name="ticker_validator",
+    model="gemini-2.0-pro",
+    instruction=(
+        "Use the validate_ticker tool to check if the ticker provided by the "
+        "user exists on Yahoo Finance. If the ticker is invalid, return an "
+        "error message and stop the workflow."
+    ),
+    tools=[validate_ticker],
+    output_key="validated_ticker",
+)
+
+news_retrieval_agent = LlmAgent(
+    name="news_retriever",
+    model="gemini-2.0-pro",
+    instruction=(
+        "Retrieve recent news for the validated ticker during the specified "
+        "week using search_news. Provide a list of headlines and short "
+        "summaries."
+    ),
+    tools=[search_news],
+)
+
+financial_summary_agent = LlmAgent(
+    name="financial_summary",
+    model="gemini-2.0-pro",
+    instruction=(
+        "Gather recent earnings or financial statement information using "
+        "summarize_financials for the validated ticker."
+    ),
+    tools=[summarize_financials],
+)
+
+sentiment_agent = LlmAgent(
+    name="sentiment_analyzer",
+    model="gemini-2.0-pro",
+    instruction=(
+        "Evaluate the sentiment of the news articles using analyze_sentiment."
+    ),
+    tools=[analyze_sentiment],
+)
+
+root_agent = LlmAgent(
+    name="finance_supervisor",
+    model="gemini-2.0-pro",
+    description="Supervisor agent for stock price movement analysis.",
+    instruction=(
+        "You converse with the user to obtain a stock ticker and week. "
+        "Then coordinate sub-agents to validate the ticker, collect news, "
+        "summarize financial data and analyze sentiment. Provide a concise "
+        "weekly report of potential reasons for stock price movements."
+    ),
+    sub_agents=[
+        ticker_validation_agent,
+        news_retrieval_agent,
+        financial_summary_agent,
+        sentiment_agent,
+    ],
+)

--- a/agents/qa_system_finance/util.py
+++ b/agents/qa_system_finance/util.py
@@ -60,7 +60,7 @@ def search_news(query: str, start: datetime, end: datetime) -> dict:
                 articles.append(
                     {"title": title, "url": link, "snippet": snippet}
                 )
-            if len(articles) >= 5:
+            if len(articles) >= MAX_ARTICLES:
                 break
         return {"status": "success", "articles": articles}
     except Exception as err:  # pragma: no cover - network

--- a/agents/qa_system_finance/util.py
+++ b/agents/qa_system_finance/util.py
@@ -36,7 +36,7 @@ def validate_ticker(ticker: str) -> dict:
             return {"status": "success", "ticker": ticker.upper()}
         return {
             "status": "error",
-            "error_message": f"Ticker '{ticker}' not found.",
+            "error_message": f"Ticker '{ticker.upper()}' not found.",
         }
     except Exception as err:  # pragma: no cover - network
         return {"status": "error", "error_message": str(err)}

--- a/agents/qa_system_finance/util.py
+++ b/agents/qa_system_finance/util.py
@@ -1,0 +1,102 @@
+import json
+from datetime import datetime
+from urllib.parse import quote_plus
+from urllib.request import Request, urlopen
+
+POSITIVE_WORDS = {
+    "gain",
+    "growth",
+    "positive",
+    "surge",
+    "beat",
+    "up",
+    "profit",
+}
+NEGATIVE_WORDS = {
+    "loss",
+    "drop",
+    "negative",
+    "down",
+    "miss",
+    "decline",
+}
+
+
+def validate_ticker(ticker: str) -> dict:
+    """Validate ticker symbol using Yahoo Finance."""
+    url = (
+        "https://query1.finance.yahoo.com/v7/finance/quote?symbols="
+        + quote_plus(ticker)
+    )
+    try:
+        with urlopen(url) as resp:
+            data = json.load(resp)
+        result = data.get("quoteResponse", {}).get("result", [])
+        if result:
+            return {"status": "success", "ticker": ticker.upper()}
+        return {
+            "status": "error",
+            "error_message": f"Ticker '{ticker}' not found.",
+        }
+    except Exception as err:  # pragma: no cover - network
+        return {"status": "error", "error_message": str(err)}
+
+
+def search_news(query: str, start: datetime, end: datetime) -> dict:
+    """Search news on DuckDuckGo between start and end dates."""
+    date_range = f"{start.strftime('%Y-%m-%d')}..{end.strftime('%Y-%m-%d')}"
+    q = quote_plus(f"{query} {date_range}")
+    url = f"https://duckduckgo.com/?q={q}&iar=news&ia=news&format=json"
+    try:
+        req = Request(url, headers={"User-Agent": "Mozilla/5.0"})
+        with urlopen(req) as resp:
+            data = json.load(resp)
+        articles = []
+        for item in data.get("results", []) or data.get("RelatedTopics", []):
+            title = item.get("title") or item.get("Text")
+            link = item.get("url") or item.get("FirstURL")
+            snippet = item.get("snippet") or ""
+            if title and link:
+                articles.append(
+                    {"title": title, "url": link, "snippet": snippet}
+                )
+            if len(articles) >= 5:
+                break
+        return {"status": "success", "articles": articles}
+    except Exception as err:  # pragma: no cover - network
+        return {"status": "error", "error_message": str(err)}
+
+
+def summarize_financials(ticker: str) -> dict:
+    """Fetch simple earnings summary from Yahoo Finance."""
+    url = (
+        "https://query1.finance.yahoo.com/v10/finance/quoteSummary/"
+        + quote_plus(ticker)
+        + "?modules=earnings"
+    )
+    try:
+        with urlopen(url) as resp:
+            data = json.load(resp)
+        summary = data.get("quoteSummary", {}).get("result", [{}])[0]
+        return {"status": "success", "summary": summary}
+    except Exception as err:  # pragma: no cover - network
+        return {"status": "error", "error_message": str(err)}
+
+
+def analyze_sentiment(text: str) -> dict:
+    """Very small sentiment analyzer based on word lists."""
+    lower = text.lower()
+    score = 0
+    for w in POSITIVE_WORDS:
+        if w in lower:
+            score += 1
+    for w in NEGATIVE_WORDS:
+        if w in lower:
+            score -= 1
+    if score > 0:
+        sentiment = "positive"
+    elif score < 0:
+        sentiment = "negative"
+    else:
+        sentiment = "neutral"
+    return {"status": "success", "sentiment": sentiment, "score": score}


### PR DESCRIPTION
## Summary
- implement new QA workflow for stock price analysis
- add helper utilities for ticker validation, news retrieval, financial summaries and sentiment analysis

## Testing
- `uv run black agents/qa_system_finance -l 79`
- `uv run isort agents/qa_system_finance`


------
https://chatgpt.com/codex/tasks/task_e_684d833c3e9883218a728c82aa13a422