### PR TITLE
Add langchain-core dependency to project requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "google-adk",
     "python-dotenv",
     "yfinance>=0.2.63",
+    "langchain-core>=0.3.65",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This pull request includes a small change to the `pyproject.toml` file. The change adds a new dependency, `langchain-core>=0.3.65`, to the `dependencies` list.